### PR TITLE
Update api.js

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -38,7 +38,7 @@ class sm {
       actorSkill = tokenD.actor.data.items.find(i => (i.name === 'Untrained' || i.name === 'Unskilled Attempt' ) );
     }
     skillName = actorSkill.name;
-    return await game.swade.rollItemMacro(skillName);
+    return await tokenD.actor.rollSkill(skillName);
   }
 
 


### PR DESCRIPTION
This will solve compatibility with swade tools. 
The problem: 
The function rollSkill() returns rollItemMacro() wich is the only system function swade tools overrides (to make macros work)
The solution: 
Changed the return to actor.rollSkill() wich is what rollItemMacro() does with skills.